### PR TITLE
Fix Config struct ABI mismatch with ASM STRUC

### DIFF
--- a/src/types.rs
+++ b/src/types.rs
@@ -109,10 +109,10 @@ pub struct Config {
     pub is_syscall: u32,
 
     /// System Service Number (SSN)
-    pub ssn: u16,
+    pub ssn: u32,
 
     /// Arguments that will be passed to the function that will be spoofed
-    pub number_args: u32,
+    pub number_args: u64,
     pub arg01: *const c_void,
     pub arg02: *const c_void,
     pub arg03: *const c_void,

--- a/src/uwd.rs
+++ b/src/uwd.rs
@@ -195,7 +195,7 @@ pub mod __private {
 
         // Prepare arguments
         let len = args.len();
-        config.number_args = len as u32;
+        config.number_args = len as u64;
         
         for (i, &arg) in args.iter().take(len).enumerate() {
             match i {
@@ -224,7 +224,7 @@ pub mod __private {
                 }
 
                 config.is_syscall = true as u32;
-                config.ssn = dinvk::ssn(name, ntdll).context(s!("ssn not found"))?;
+                config.ssn = dinvk::ssn(name, ntdll).context(s!("ssn not found"))?.into();
                 config.spoof_function = dinvk::get_syscall_address(addr)
                     .context(s!("syscall address not found"))? as *const c_void;
             }
@@ -294,7 +294,7 @@ pub mod __private {
 
         // Prepare arguments
         let len = args.len();
-        config.number_args = len as u32;
+        config.number_args = len as u64;
         
         for (i, &arg) in args.iter().take(len).enumerate() {
             match i {
@@ -328,7 +328,7 @@ pub mod __private {
                 }
 
                 config.is_syscall = true as u32;
-                config.ssn = dinvk::ssn(name, ntdll).context(s!("ssn not found"))?;
+                config.ssn = dinvk::ssn(name, ntdll).context(s!("ssn not found"))?.into();
                 config.spoof_function = dinvk::get_syscall_address(addr)
                     .context(s!("syscall address not found"))? as *const c_void;
             }


### PR DESCRIPTION
`ssn` and `number_args` in the Rust `Config` struct don't match the ASM STRUC sizes (`RESD`/`RESQ`), causing a 4-byte misalignment of all arg fields under `repr(C)`.

- `ssn`: `u16` -> `u32` (matches `.Ssn RESD 1`)
- `number_args`: `u32` -> `u64` (matches `.NArgs RESQ 1`)